### PR TITLE
Feature/searchdel

### DIFF
--- a/src/main/scala/commands/Help.scala
+++ b/src/main/scala/commands/Help.scala
@@ -21,6 +21,7 @@ class Help extends BaseCommand {
       "\tmeta {oid}             - show all metadata fields associated with the given object. Get the OID from `search` or `lookup`.",
       "\tget {oid}              - download the file content of {oid} to the current directory.",
       "\tdelete {oid}           - delete the object from the appliance. Note that if there is no Trash period configured, the file will be gone baby gone.",
+      "\tsearchdel {query-string} - delete every object that matches the given query string. The list of objects to delete is shown first and you are prompted whether to continue or not",
       "\tset timeout {value}    - changes the async timeout parameter. {value} is a string that must parse to FiniteDuration, e.g. '1 minute' or '2 hours'. Default is one minute.",
       "\tset pagesize {value}   - changes the number of rows to be printed before pausing for QUIT/CONTINUE when performing a search",
       "\tshow headers {on|off}  - set whether to show the header line when searching",

--- a/src/main/scala/commands/Search.scala
+++ b/src/main/scala/commands/Search.scala
@@ -1,19 +1,15 @@
 package commands
-import akka.Done
 import akka.actor.ActorSystem
-import akka.stream.{Attributes, ClosedShape, Inlet, KillSwitch, KillSwitches, Materializer, SinkShape}
-import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink}
-import akka.stream.stage.{AbstractInHandler, AbstractOutHandler, GraphStage, GraphStageLogic, GraphStageWithMaterializedValue}
-import com.om.mxs.client.japi.{Constants, MatrixStore, SearchTerm}
+import akka.stream.{KillSwitches, Materializer}
 import interpreter.Session
-import models.ObjectMatrixEntry
 import org.jline.reader.LineReader
 import org.jline.terminal.Terminal
-import streamcomponents.OMFastSearchSource
 import scala.concurrent.{Await, Future, Promise}
 import scala.util.{Success, Try}
 
 class Search extends BaseCommand {
+  import SearchFunctions._
+
   val baseIncludeFields = Array(
     "MXFS_PATH",
     "MXFS_FILENAME",
@@ -26,126 +22,15 @@ class Search extends BaseCommand {
     "MXFS_INTRASH"
   )
 
-  class PrintResultSink(includeFields:Array[String], itemsPerPage:Int, showHeaders:Boolean, killSwitch:KillSwitch)(implicit terminal:Terminal, lineReader: LineReader)
-    extends GraphStageWithMaterializedValue[SinkShape[ObjectMatrixEntry], Future[Done]] {
-    private val in:Inlet[ObjectMatrixEntry] = Inlet.create("PrintResultSink.in")
-
-    private val fieldsToPrint = includeFields.filter(n=>{ //we print these anyway
-      !baseIncludeFields.contains(n)
-    })
-    override def shape: SinkShape[ObjectMatrixEntry] = SinkShape.of(in)
-
-    def paddedString(source:String, padTo:Int):String = {
-      if(source.length>=padTo) {
-        source
-      } else {
-        source + (" " * (padTo-source.length))
-      }
-    }
-
-    def printHeaderLine(): Unit = {
-      val elems = Seq(
-        paddedString("OID", 42),
-        paddedString("File size", 8),
-        paddedString("Filename", 20),
-      ) ++ fieldsToPrint.map(_.padTo(10," "))
-      terminal.writer().println(elems.mkString("\t"))
-      terminal.writer().flush()
-    }
-
-    override def createLogicAndMaterializedValue(inheritedAttributes: Attributes)= {
-      val completionPromise = Promise[Done]()
-
-      val logic = new GraphStageLogic(shape) {
-        private var ctr:Int = 0
-
-        setHandler(in, new AbstractInHandler {
-          override def onPush(): Unit = {
-            val result = grab(in)
-            val fields = Seq(
-              "Path or filename: " + result.maybeGetPath().getOrElse("[no path]"),
-              "OID: " + result.oid,
-              "Size in bytes: " + result.getFileSize.map(_.toString).getOrElse("[no size]"),
-              "MXFS_MODIFICATION_TIME: " + result.timeAttribute("MXFS_MODIFICATION_TIME"),
-              "MXFS_ACCESS_TIME: " + result.timeAttribute("MXFS_ACCESS_TIME"),
-              "MXFS_CREATION_TIME: " + result.timeAttribute("MXFS_CREATION_TIME"),
-              "MXFS_ARCHIVE_TIME: " + result.timeAttribute("MXFS_ARCHIVE_TIME"),
-            ) ++ fieldsToPrint.map(f => s"$f: " + result.stringAttribute(f).getOrElse("-"))
-
-            terminal.writer().println(fields.mkString("\n"))
-            terminal.writer().println("------------")
-            terminal.writer().flush()
-            ctr += 1
-            if(ctr==itemsPerPage) {
-              terminal.writer().println("Press Q [ENTER] to quit or [ENTER] for the next page")
-              terminal.writer().flush()
-              try {
-                val charsRead = lineReader.readLine(' ')
-
-                if (charsRead.charAt(0) == 'q' || charsRead.charAt(0) == 'Q') {
-                  killSwitch.shutdown()
-                  return
-                }
-                ctr = 0
-              } catch {
-                case _:IndexOutOfBoundsException=>
-                  ctr=0
-              }
-            }
-            pull(in)
-          }
-
-          override def onUpstreamFinish(): Unit = {
-            completionPromise.success(Done.done())
-          }
-
-          override def onUpstreamFailure(ex: Throwable): Unit = {
-            completionPromise.failure(ex)
-          }
-        })
-
-        override def preStart(): Unit = {
-          pull(in)
-        }
-      }
-
-      (logic, completionPromise.future)
-    }
-  }
-
-  def doSearch(params:Seq[String], mxs:MatrixStore, vaultId:String, itemsPerPage:Int, showHeaders:Boolean, includeFields:Array[String])
-              (implicit terminal:Terminal, lineReader:LineReader, actorSystem: ActorSystem, mat:Materializer) = {
-    val baseQueryString = s"${params(1)}"
-    val queryStringWithIncludes = if(includeFields.isEmpty) {
-      baseQueryString
-    } else {
-      baseQueryString + s"\nkeywords:__mxs_id,${includeFields.mkString(",")}"
-    }
-
-    val terms = Array(SearchTerm.createSimpleTerm(Constants.CONTENT, queryStringWithIncludes))
-
-    val ks = KillSwitches.shared("user-quit")
-
-    val graph = GraphDSL.create(new PrintResultSink(includeFields, itemsPerPage, showHeaders, ks)) { implicit builder=> sink=>
-      import akka.stream.scaladsl.GraphDSL.Implicits._
-
-      val ksFlow = builder.add(ks.flow[ObjectMatrixEntry])
-      val src = builder.add(new OMFastSearchSource(mxs, vaultId, terms, includeFields, contentSearchBareTerm = true))
-
-      src ~> ksFlow ~> sink
-      ClosedShape
-    }
-
-    RunnableGraph.fromGraph(graph).run()
-  }
-
   override def run(params: Seq[String], session: Session)
                   (implicit terminal: Terminal, lineReader: LineReader, actorSystem: ActorSystem, mat: Materializer): Try[Session] = {
     (session.activeConnection, session.activeVaultId) match {
       case (Some(mxs), Some(vaultId))=>
         Try {
+          val ks = KillSwitches.shared("user-quit")
+          val sinkFactory = new PrintResultSink(baseIncludeFields ++ session.fields, session.fields.toArray, session.itemsPerPage, session.showHeaders, ks)
           Await.result(
-            doSearch(params, mxs, vaultId, session.itemsPerPage, session.showHeaders, baseIncludeFields ++ session.fields),
+            doSearch(params, mxs, vaultId, baseIncludeFields ++ session.fields, sinkFactory, ks),
             session.asyncTimeout
           )
         }.map(_=>session)

--- a/src/main/scala/commands/SearchDel.scala
+++ b/src/main/scala/commands/SearchDel.scala
@@ -1,0 +1,113 @@
+package commands
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.stage.{AbstractInHandler, GraphStageLogic, GraphStageWithMaterializedValue}
+import akka.stream.{Attributes, Inlet, KillSwitch, KillSwitches, Materializer, SinkShape}
+import interpreter.Session
+import models.ObjectMatrixEntry
+import org.jline.reader.LineReader
+import org.jline.terminal.Terminal
+
+import scala.collection.mutable
+import scala.concurrent.{Await, Future, Promise}
+import scala.util.{Success, Try}
+
+class SearchDel extends BaseCommand {
+  import SearchFunctions._
+
+  val baseIncludeFields = Array(
+    "MXFS_PATH",
+    "MXFS_FILENAME",
+    "__mxs__length",
+    "MXFS_INTRASH"
+  )
+
+  class ResultListSink(killSwitch:KillSwitch)(implicit terminal:Terminal, lineReader: LineReader)
+    extends GraphStageWithMaterializedValue[SinkShape[ObjectMatrixEntry], Future[(Seq[String], Long)]] {
+    private val in:Inlet[ObjectMatrixEntry] = Inlet.create("PrintResultSink.in")
+
+    override def shape: SinkShape[ObjectMatrixEntry] = SinkShape.of(in)
+
+    override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[(Seq[String], Long)]) = {
+      val completionPromise = Promise[(Seq[String], Long)]()
+
+      val logic = new GraphStageLogic(shape) {
+        private var oidList = mutable.Seq[String]()
+        private var totalSize:Long = 0
+        private var ctr = 0
+
+        setHandler(in, new AbstractInHandler {
+          override def onPush(): Unit = {
+            val entry = grab(in)
+            terminal.writer().println(s"${entry.oid}\t${maybeUserFriendlySize(entry.getFileSize)}\t${entry.maybeGetPath().getOrElse("[no path]")}")
+            oidList = oidList.appended(entry.oid)
+            totalSize += entry.getFileSize.getOrElse(0L)
+            ctr +=1
+            if(ctr>10) {
+              terminal.writer().flush()
+              ctr=0
+            }
+            pull(in)
+          }
+
+          override def onUpstreamFinish(): Unit = {
+            completionPromise.success((oidList.toSeq, totalSize))  //convert to an immutable seq when returning
+          }
+
+          override def onUpstreamFailure(ex: Throwable): Unit = {
+            completionPromise.failure(ex)
+          }
+        })
+
+        override def preStart(): Unit = {
+          pull(in)
+        }
+      }
+
+      (logic, completionPromise.future)
+    }
+  }
+
+  override def run(params: Seq[String], session: Session)
+                  (implicit terminal: Terminal, lineReader: LineReader, actorSystem: ActorSystem, mat: Materializer): Try[Session] = {
+    (session.activeConnection, session.activeVaultId) match {
+      case (Some(mxs), Some(vaultId))=>
+        Try {
+          val ks = KillSwitches.shared("user-quit")
+          val sinkFactory = new ResultListSink(ks)
+          terminal.writer().println(s"The following files will be deleted:\n")
+          terminal.writer().flush()
+          val result = Await.result(
+            doSearch(params, mxs, vaultId, baseIncludeFields ++ session.fields, sinkFactory, ks),
+            session.asyncTimeout
+          )
+          val oidsToDelete = result._1
+          val totalSizeToDelete = result._2
+          terminal.writer().println(s"${oidsToDelete.length} files totalling ${userFriendlySize(totalSizeToDelete)} will be deleted. Are you sure you want to continue? (y/n)")
+          terminal.writer().flush()
+          val promptResult = terminal.reader().read(1800L)
+          promptResult match {
+            case -1=>
+              terminal.writer().println("Got EOF while waiting for user response")
+              terminal.writer().flush()
+            case -2=>
+              terminal.writer().println("Error while waiting for user response")
+              terminal.writer().flush()
+            case _=>
+              val char = promptResult.toChar
+              if(char.toLower=='y') {
+                terminal.writer().println("Not implemented yet!")
+
+              } else {
+                terminal.writer().println("Not deleting anything then")
+              }
+              terminal.writer().flush()
+          }
+        }.map(_=>session)
+      case _=>
+        terminal.writer().println("You must connect to a vault before you can search")
+        terminal.writer().flush()
+        Success(session)
+    }
+  }
+}

--- a/src/main/scala/commands/SearchFunctions.scala
+++ b/src/main/scala/commands/SearchFunctions.scala
@@ -1,0 +1,147 @@
+package commands
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.{Attributes, ClosedShape, Inlet, KillSwitch, KillSwitches, Materializer, SharedKillSwitch, SinkShape}
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph}
+import akka.stream.stage.{AbstractInHandler, GraphStageLogic, GraphStageWithMaterializedValue}
+import com.om.mxs.client.japi.{Constants, MatrixStore, SearchTerm}
+import models.ObjectMatrixEntry
+import org.jline.reader.LineReader
+import org.jline.terminal.Terminal
+import streamcomponents.OMFastSearchSource
+
+import scala.concurrent.{Future, Promise}
+
+object SearchFunctions {
+  class PrintResultSink(includeFields:Array[String],
+                        fieldsToPrint:Array[String],
+                        itemsPerPage:Int,
+                        showHeaders:Boolean,
+                        killSwitch:KillSwitch)(implicit terminal:Terminal, lineReader: LineReader)
+    extends GraphStageWithMaterializedValue[SinkShape[ObjectMatrixEntry], Future[Done]] {
+    private val in:Inlet[ObjectMatrixEntry] = Inlet.create("PrintResultSink.in")
+
+    override def shape: SinkShape[ObjectMatrixEntry] = SinkShape.of(in)
+
+    def paddedString(source:String, padTo:Int):String = {
+      if(source.length>=padTo) {
+        source
+      } else {
+        source + (" " * (padTo-source.length))
+      }
+    }
+
+    def printHeaderLine(): Unit = {
+      val elems = Seq(
+        paddedString("OID", 42),
+        paddedString("File size", 8),
+        paddedString("Filename", 20),
+      ) ++ fieldsToPrint.map(_.padTo(10," "))
+      terminal.writer().println(elems.mkString("\t"))
+      terminal.writer().flush()
+    }
+
+    override def createLogicAndMaterializedValue(inheritedAttributes: Attributes)= {
+      val completionPromise = Promise[Done]()
+
+      val logic = new GraphStageLogic(shape) {
+        private var ctr:Int = 0
+
+        setHandler(in, new AbstractInHandler {
+          override def onPush(): Unit = {
+            val result = grab(in)
+            val fields = Seq(
+              "Path or filename: " + result.maybeGetPath().getOrElse("[no path]"),
+              "OID: " + result.oid,
+              "Size in bytes: " + result.getFileSize.map(_.toString).getOrElse("[no size]"),
+              "MXFS_MODIFICATION_TIME: " + result.timeAttribute("MXFS_MODIFICATION_TIME"),
+              "MXFS_ACCESS_TIME: " + result.timeAttribute("MXFS_ACCESS_TIME"),
+              "MXFS_CREATION_TIME: " + result.timeAttribute("MXFS_CREATION_TIME"),
+              "MXFS_ARCHIVE_TIME: " + result.timeAttribute("MXFS_ARCHIVE_TIME"),
+            ) ++ fieldsToPrint.map(f => s"$f: " + result.stringAttribute(f).getOrElse("-"))
+
+            terminal.writer().println(fields.mkString("\n"))
+            terminal.writer().println("------------")
+            terminal.writer().flush()
+            ctr += 1
+            if(ctr==itemsPerPage) {
+              terminal.writer().println("Press Q [ENTER] to quit or [ENTER] for the next page")
+              terminal.writer().flush()
+              try {
+                val charsRead = lineReader.readLine(' ')
+
+                if (charsRead.charAt(0) == 'q' || charsRead.charAt(0) == 'Q') {
+                  killSwitch.shutdown()
+                  return
+                }
+                ctr = 0
+              } catch {
+                case _:IndexOutOfBoundsException=>
+                  ctr=0
+              }
+            }
+            pull(in)
+          }
+
+          override def onUpstreamFinish(): Unit = {
+            completionPromise.success(Done.done())
+          }
+
+          override def onUpstreamFailure(ex: Throwable): Unit = {
+            completionPromise.failure(ex)
+          }
+        })
+
+        override def preStart(): Unit = {
+          pull(in)
+        }
+      }
+
+      (logic, completionPromise.future)
+    }
+  }
+
+  def doSearch[T](params:Seq[String],
+               mxs:MatrixStore,
+               vaultId:String,
+               includeFields:Array[String],
+               sinkFactory: GraphStageWithMaterializedValue[SinkShape[ObjectMatrixEntry], Future[T]],
+               killSwitch: SharedKillSwitch)
+              (implicit terminal:Terminal, lineReader:LineReader, actorSystem: ActorSystem, mat:Materializer) = {
+    val baseQueryString = s"${params(1)}"
+    val queryStringWithIncludes = if(includeFields.isEmpty) {
+      baseQueryString
+    } else {
+      baseQueryString + s"\nkeywords:__mxs_id,${includeFields.mkString(",")}"
+    }
+
+    val terms = Array(SearchTerm.createSimpleTerm(Constants.CONTENT, queryStringWithIncludes))
+
+    val graph = GraphDSL.create(sinkFactory) { implicit builder=> sink=>
+      import akka.stream.scaladsl.GraphDSL.Implicits._
+
+      val ksFlow = builder.add(killSwitch.flow[ObjectMatrixEntry])
+      val src = builder.add(new OMFastSearchSource(mxs, vaultId, terms, includeFields, contentSearchBareTerm = true))
+
+      src ~> ksFlow ~> sink
+      ClosedShape
+    }
+
+    RunnableGraph.fromGraph(graph).run()
+  }
+
+  def maybeUserFriendlySize(maybeSize:Option[Long]) = maybeSize.map(userFriendlySize(_)).getOrElse("(no size)")
+
+  def userFriendlySize(rawSizeInBytes:Long, iteration:Int=0):String = {
+    val suffixes = Seq("bytes","KiB", "MiB", "GiB", "TiB", "PiB")
+
+    if(iteration>=suffixes.size-1) {
+      s"$rawSizeInBytes ${suffixes(iteration)}"
+    } else if(rawSizeInBytes>1024) {
+      userFriendlySize(rawSizeInBytes/1024, iteration+1)
+    } else {
+      s"$rawSizeInBytes ${suffixes(iteration)}"
+    }
+  }
+}

--- a/src/main/scala/interpreter/Interpreter.scala
+++ b/src/main/scala/interpreter/Interpreter.scala
@@ -19,6 +19,7 @@ class Interpreter(implicit val actorSystem: ActorSystem, mat:Materializer) {
     LeafToken("search", new Search),
     LeafToken("lookup", new LookupFilename),
     LeafToken("delete", new Delete),
+    LeafToken("searchdel", new SearchDel),
     LeafToken("md5", new MD5),
     LeafToken("meta", new Meta),
     LeafToken("get", new Get),


### PR DESCRIPTION
## What does this change?

Adds a `searchdel` command that allows the deletion of _everything_ matching a given search.  The items to be deleted are listed and a summary shown, then the user is prompted whether to continue or not

## How to test
Load the updated version and issue a `searchdel` command against a vault.  Make sure you don't mind deleting the content!

## How can we measure success?

Able to delete stuff from nearlines that is not required any more

