### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,9 +27,9 @@ jobs:
       - name: Branch name
         id: branch_name
         run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+          echo SOURCE_NAME=${GITHUB_REF#refs/*/} >> "$GITHUB_OUTPUT"
+          echo SOURCE_BRANCH=${GITHUB_REF#refs/heads/} >> "$GITHUB_OUTPUT"
+          echo SOURCE_TAG=${GITHUB_REF#refs/tags/} >> "$GITHUB_OUTPUT"
 
       - name: Check branch name values
         run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Branch name
         id: branch_name
         run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+          echo SOURCE_NAME=${GITHUB_REF#refs/*/} >> "$GITHUB_OUTPUT"
+          echo SOURCE_BRANCH=${GITHUB_REF#refs/heads/} >> "$GITHUB_OUTPUT"
+          echo SOURCE_TAG=${GITHUB_REF#refs/tags/} >> "$GITHUB_OUTPUT"
 
       - name: Check branch name values
         run: |

--- a/.github/workflows/tags.yml
+++ b/.github/workflows/tags.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Branch name
         id: branch_name
         run: |
-          echo ::set-output name=SOURCE_NAME::${GITHUB_REF#refs/*/}
-          echo ::set-output name=SOURCE_BRANCH::${GITHUB_REF#refs/heads/}
-          echo ::set-output name=SOURCE_TAG::${GITHUB_REF#refs/tags/}
+          echo SOURCE_NAME=${GITHUB_REF#refs/*/} >> "$GITHUB_OUTPUT"
+          echo SOURCE_BRANCH=${GITHUB_REF#refs/heads/} >> "$GITHUB_OUTPUT"
+          echo SOURCE_TAG=${GITHUB_REF#refs/tags/} >> "$GITHUB_OUTPUT"
 
       - name: Check branch name values
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter